### PR TITLE
Corrected the Disassemblers/Decompilers link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A curated list of awesome reversing resources
     - [Practice](#practice)
     - [Hex Editors](#hex-editors)
     - [Binary Format](#binary-format)
-    - [Disassemblers](#disassemblers)
+    - [Disassemblers](#disassemblersdecompilers)
     - [Binary Analysis](#binary-analysis)
     - [Bytecode Analysis](#bytecode-analysis)
     - [Import Reconstruction](#import-reconstruction)


### PR DESCRIPTION
It was pointing to disassemblers, which does not exist.